### PR TITLE
DRAFT - CGSP-190 -  Revert MapStore2 to Default Theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "terser": "5.18.1",
     "url-loader": "0.5.7",
     "vusion-webfonts-generator": "0.4.1",
-    "webpack": "5.54.0",
+    "webpack": "5.94.0",
     "webpack-bundle-size-analyzer": "2.0.2",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "3.11.0"

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "react-notification-system": "0.2.14",
     "react-nouislider": "2.0.1",
     "react-overlays": "1.2.0",
-    "react-pdf": "5.1.0",
+    "react-pdf": "7.7.3",
     "react-player": "1.15.3",
     "react-plotly.js": "2.5.0",
     "react-quill": "1.1.0",

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mapstore2.version>DEV</mapstore2.version>
-        <tomcat.version>8.5.69</tomcat.version>
-        <tomcat.port>8082</tomcat.port>
+        <tomcat.version>9.0.90</tomcat.version>
+        <tomcat.port>8080</tomcat.port>
         <geostore-webapp.version>2.2-SNAPSHOT</geostore-webapp.version>
         <print-lib.version>2.3.1</print-lib.version>
         <http_proxy.version>1.6-SNAPSHOT</http_proxy.version>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tomcat.version>9.0.89</tomcat.version>
-        <tomcat.port>8082</tomcat.port>
+        <tomcat.version>9.0.90</tomcat.version>
+        <tomcat.port>8080</tomcat.port>
         <datadir.location>${env.MAPSTORE_DATA_DIR}</datadir.location>
         <security.integration>default</security.integration>
         <!-- <backend.debug.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000</backend.debug.args> -->

--- a/project/standard/templates/web/pom.xml
+++ b/project/standard/templates/web/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomcat.version>9.0.89</tomcat.version>
+    <tomcat.version>9.0.90</tomcat.version>
     <tomcat.port>8080</tomcat.port>
     <mapstore-services.version>1.9-SNAPSHOT</mapstore-services.version>
     <geostore-webapp.version>2.1-SNAPSHOT</geostore-webapp.version>
@@ -396,7 +396,9 @@
                 <container>
                     <containerId>tomcat9x</containerId>
                     <zipUrlInstaller>
-                        <url>https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${tomcat.version}/tomcat-${tomcat.version}.zip</url>
+                        <url>
+                            https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/${tomcat.version}/tomcat-${tomcat.version}.zip
+                        </url>
                     </zipUrlInstaller>
                 </container>
                 <configuration>

--- a/web/client/actions/__tests__/catalog-test.js
+++ b/web/client/actions/__tests__/catalog-test.js
@@ -72,7 +72,9 @@ import {
     SET_FORMAT_OPTIONS,
     setSupportedFormats, addLayerAndDescribe, ADD_LAYER_AND_DESCRIBE,
     INIT_PLUGIN,
-    initPlugin
+    initPlugin,
+    updateCatalogServices,
+    UPDATE_CATALOG_SERVICES
 } from '../catalog';
 
 import { SHOW_NOTIFICATION } from '../notifications';
@@ -253,6 +255,14 @@ describe('Test correctness of the catalog actions', () => {
         expect(retval).toExist();
         expect(retval.type).toBe(ADD_CATALOG_SERVICE);
         expect(retval.service).toBe(service);
+    });
+    it('updateCatalogServices', () => {
+        const services = [{}];
+        var retval = updateCatalogServices(services);
+
+        expect(retval).toExist();
+        expect(retval.type).toBe(UPDATE_CATALOG_SERVICES);
+        expect(retval.services).toEqual(services);
     });
     it('resetCatalog', () => {
         var retval = resetCatalog();

--- a/web/client/actions/__tests__/layers-test.js
+++ b/web/client/actions/__tests__/layers-test.js
@@ -20,6 +20,8 @@ import {
     ADD_LAYER,
     REMOVE_LAYER,
     SHOW_SETTINGS,
+    replaceLayers,
+    REPLACE_LAYERS,
     HIDE_SETTINGS,
     UPDATE_SETTINGS,
     REFRESH_LAYERS,
@@ -238,6 +240,14 @@ describe('Test correctness of the layers actions', () => {
         expect(action.node).toBe("node1");
         expect(action.nodeType).toBe("layers");
         expect(action.options).toEqual({opacity: 0.5});
+    });
+
+    it('replaceLayers', () => {
+        const layers = [{}];
+        const action = replaceLayers(layers);
+        expect(action).toExist();
+        expect(action.type).toBe(REPLACE_LAYERS);
+        expect(action.layers).toEqual(layers);
     });
 
     it('hide settings', () => {

--- a/web/client/actions/catalog.js
+++ b/web/client/actions/catalog.js
@@ -38,6 +38,7 @@ export const CHANGE_SERVICE_FORMAT = 'CATALOG:CHANGE_SERVICE_FORMAT';
 export const FOCUS_SERVICES_LIST = 'CATALOG:FOCUS_SERVICES_LIST';
 export const CHANGE_URL = 'CATALOG:CHANGE_URL';
 export const ADD_CATALOG_SERVICE = 'CATALOG:ADD_CATALOG_SERVICE';
+export const UPDATE_CATALOG_SERVICES = 'CATALOG:UPDATE_CATALOG_SERVICES';
 export const DELETE_CATALOG_SERVICE = 'CATALOG:DELETE_CATALOG_SERVICE';
 export const ADD_SERVICE = 'CATALOG:ADD_SERVICE';
 export const DELETE_SERVICE = 'CATALOG:DELETE_SERVICE';
@@ -182,6 +183,17 @@ export function addCatalogService(service) {
     return {
         type: ADD_CATALOG_SERVICE,
         service
+    };
+}
+/**
+ *
+ * @param {object[]} services list of services to full replace catalog ones
+ * @returns
+ */
+export function updateCatalogServices(services) {
+    return {
+        type: UPDATE_CATALOG_SERVICES,
+        services
     };
 }
 export function deleteCatalogService(service) {

--- a/web/client/actions/layers.js
+++ b/web/client/actions/layers.js
@@ -36,7 +36,19 @@ export const FILTER_LAYERS = 'LAYERS:FILTER_LAYERS';
 export const SHOW_LAYER_METADATA = 'LAYERS:SHOW_LAYER_METADATA';
 export const HIDE_LAYER_METADATA = 'LAYERS:HIDE_LAYER_METADATA';
 export const UPDATE_SETTINGS_PARAMS = 'LAYERS:UPDATE_SETTINGS_PARAMS';
+export const REPLACE_LAYERS = 'LAYERS:REPLACE_LAYERS';
 
+/**
+ * full replacement of layers in layers state
+ * @param {object[]} layers the new layers to replace in the state
+ * @returns
+ */
+export function replaceLayers(layers) {
+    return {
+        type: REPLACE_LAYERS,
+        layers
+    };
+}
 export function showSettings(node, nodeType, options) {
     return {
         type: SHOW_SETTINGS,

--- a/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
+++ b/web/client/components/catalog/__tests__/CatalogServiceEditor-test.jsx
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 import expect from 'expect';
 import TestUtils from 'react-dom/test-utils';
 import CatalogServiceEditor from '../CatalogServiceEditor';
-import {defaultPlaceholder} from "../editor/MainFormUtils";
 
 const givenWmsService = {
     url: "url",
@@ -139,13 +138,6 @@ describe('Test CatalogServiceEditor', () => {
 
         const isLocalizedLayerStylesOption = document.querySelector('[data-qa="service-lacalized-layer-styles-option"]');
         expect(isLocalizedLayerStylesOption).toBeNull;
-    });
-    it('test defaultPlaceholder function for the main form placeholder urls', () => {
-        let service = {
-            type: "wms"
-        };
-        let placeholder = defaultPlaceholder(service);
-        expect(placeholder).toBe("e.g. https://mydomain.com/geoserver/wms");
     });
     it('test save and delete button when saving', () => {
         ReactDOM.render(<CatalogServiceEditor

--- a/web/client/components/catalog/editor/MainForm.jsx
+++ b/web/client/components/catalog/editor/MainForm.jsx
@@ -16,7 +16,7 @@ import InfoPopover from '../../widgets/widget/InfoPopover';
 import { FormControl as FC, Form, Col, FormGroup, ControlLabel, Alert } from "react-bootstrap";
 
 import localizedProps from '../../misc/enhancers/localizedProps';
-import {defaultPlaceholder, checkUrl} from "./MainFormUtils";
+import {checkUrl} from "./MainFormUtils";
 
 const FormControl = localizedProps('placeholder')(FC);
 
@@ -35,7 +35,7 @@ const DefaultURLEditor = ({ service = {}, onChangeUrl = () => { } }) => {
                     style={{
                         textOverflow: "ellipsis"
                     }}
-                    placeholder={defaultPlaceholder(service)}
+                    placeholder={'catalog.urlPlaceHolders.' + service.type}
                     value={service && service.url}
                     onChange={(e) => onChangeUrl(e.target.value)}/>
             </Col>
@@ -89,7 +89,7 @@ const TmsURLEditor = ({ serviceTypes = [], onChangeServiceProperty, service = {}
                         style={{
                             textOverflow: "ellipsis"
                         }}
-                        placeholder={"e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}"}
+                        placeholder="catalog.urlPlaceHolders.custom"
                         value={service && service.url}
                         onChange={(e) => onChangeUrl(e.target.value)} />
                 </React.Fragment>
@@ -101,7 +101,7 @@ const TmsURLEditor = ({ serviceTypes = [], onChangeServiceProperty, service = {}
                             style={{
                                 textOverflow: "ellipsis"
                             }}
-                            placeholder={defaultPlaceholder(service)}
+                            placeholder="catalog.urlPlaceHolders.tms"
                             value={service && service.url}
                             onChange={(e) => onChangeUrl(e.target.value)} />
                     </React.Fragment>
@@ -121,7 +121,7 @@ const COGEditor = ({ service = {}, onChangeServiceProperty = () => { } }) => {
                     style={{
                         textOverflow: "ellipsis"
                     }}
-                    placeholder={defaultPlaceholder(service)}
+                    placeholder="catalog.urlPlaceHolders.cog"
                     value={service && service.records && service.records.map(record => record?.url)?.join(',')}
                     onChange={(e) => {
                         let urls = e.target.value || "";

--- a/web/client/components/catalog/editor/MainFormUtils.js
+++ b/web/client/components/catalog/editor/MainFormUtils.js
@@ -1,25 +1,4 @@
 import url from 'url';
-
-export const defaultPlaceholder = (service) => {
-    let urlPlaceholder = {
-        "wfs": "e.g. https://mydomain.com/geoserver/wfs",
-        "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
-        "wms": "e.g. https://mydomain.com/geoserver/wms",
-        "csw": "e.g. https://mydomain.com/geoserver/csw",
-        "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
-        "3dtiles": "e.g. https://mydomain.com/tileset.json",
-        "cog": "e.g. https://mydomain.com/cog.tif",
-        "model": "e.g. https://mydomain.com/filename.ifc",
-        "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
-    };
-    for ( const [key, value] of Object.entries(urlPlaceholder)) {
-        if ( key === service.type) {
-            return value;
-        }
-    }
-    return true;
-};
-
 /**
  * Check if the URL typed is valid or not
  * @param {string} catalogUrl The URL of the catalog

--- a/web/client/components/import/dragZone/enhancers/__tests__/testData.js
+++ b/web/client/components/import/dragZone/enhancers/__tests__/testData.js
@@ -16,7 +16,8 @@ export const getFile = (url, fileName = "file") =>
         responseType: 'arraybuffer'
     }))
         .map( res => {
-            return new File([new Blob([res.data], {type: res.headers['response-type']})], fileName);
+            const contentType = res.headers['content-type'] === 'null' ? undefined : res.headers['content-type'];
+            return new File([res.data], fileName, {type: contentType});
         });
 
 // PDF_FILE: new File(b64toBlob('UEsDBAoAAAAAACGPaktDvrfoAQAAAAEAAAAKAAAAc2FtcGxlLnR4dGFQSwECPwAKAAAAAAAhj2pLQ7636AEAAAABAAAACgAkAAAAAAAAACAAAAAAAAAAc2FtcGxlLnR4dAoAIAAAAAAAAQAYAGILh+1EWtMBy3f86URa0wHLd/zpRFrTAVBLBQYAAAAAAQABAFwAAAApAAAAAAA=', 'application/pdf'), "file.pdf"),

--- a/web/client/components/print/PrintPreview.jsx
+++ b/web/client/components/print/PrintPreview.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Glyphicon } from 'react-bootstrap';
-import { Document, Page } from 'react-pdf/dist/umd/entry.webpack';
+import { Document, Page } from 'react-pdf';
 import Button from '../misc/Button';
 
 

--- a/web/client/epics/featuregrid.js
+++ b/web/client/epics/featuregrid.js
@@ -11,8 +11,7 @@ import {get, head, isEmpty, find, castArray, includes, reduce} from 'lodash';
 import { LOCATION_CHANGE } from 'connected-react-router';
 import axios from '../libs/ajax';
 import bbox from '@turf/bbox';
-import { fidFilter } from '../utils/ogc/Filter/filter';
-import { getDefaultFeatureProjection, getPagesToLoad, gridUpdateToQueryUpdate, updatePages  } from '../utils/FeatureGridUtils';
+import { createChangesTransaction, getDefaultFeatureProjection, getPagesToLoad, gridUpdateToQueryUpdate, updatePages  } from '../utils/FeatureGridUtils';
 
 import assign from 'object-assign';
 import {
@@ -232,15 +231,6 @@ const addPagination = (filterObj, pagination) => ({
     pagination
 });
 
-const createChangesTransaction = (changes, newFeatures, {insert, update, propertyChange, getPropertyName, transaction})=>
-    transaction(
-        newFeatures.map(f => insert(f)),
-        Object.keys(changes).map( id =>
-            Object.keys(changes[id]).map(name =>
-                update([propertyChange(getPropertyName(name), changes[id][name]), fidFilter("ogc", id)])
-            )
-        )
-    );
 const createDeleteTransaction = (features, {transaction, deleteFeature}) => transaction(
     features.map(deleteFeature)
 );

--- a/web/client/plugins/LayerInfo.jsx
+++ b/web/client/plugins/LayerInfo.jsx
@@ -107,7 +107,7 @@ const LayerInfoButton = connect((state) => ({
             <ItemComponent
                 {...props}
                 glyph="layer-info"
-                tooltipId={'toc.layerFilterTooltip'}
+                tooltipId={'toc.layerInfoTooltip'}
                 onClick={() => onClick()}
             />
         );

--- a/web/client/plugins/Map.jsx
+++ b/web/client/plugins/Map.jsx
@@ -251,9 +251,8 @@ class MapPlugin extends React.Component {
         onMapTypeLoaded: () => {},
         pluginsCreator
     };
-    state = {
-        canRender: true
-    };
+
+    state = {};
 
     UNSAFE_componentWillMount() {
         // moved the font load of FontAwesome only to styleParseUtils (#9653)
@@ -378,7 +377,7 @@ class MapPlugin extends React.Component {
     };
 
     render() {
-        if (this.props.map && this.state.canRender && this.state.plugins) {
+        if (this.isValidMapConfiguration(this.props.map) && this.state.plugins) {
             const {mapOptions = {}} = this.props.map;
 
             return (
@@ -440,6 +439,15 @@ class MapPlugin extends React.Component {
             }
         });
     };
+    isValidMapConfiguration = (map) => {
+        // when the center is included inside the map config
+        // we know that the configuration has been loaded
+        // we should prevent to mount the map component
+        // in case we have a configuration like this one: { eventListeners: {}, mousePointer: '' }
+        // if we allow invalid configuration default props will be used instead
+        // initializing the map in the wrong position
+        return !!map?.center;
+    }
 }
 
 export default createPlugin('Map', {

--- a/web/client/plugins/__tests__/Map-test.jsx
+++ b/web/client/plugins/__tests__/Map-test.jsx
@@ -113,4 +113,31 @@ describe('Map Plugin', () => {
             })
             .catch(done);
     });
+    it('should not mount the map if the configuration is not valid', (done) => {
+        const { Plugin } = getPluginForTest(MapPlugin, { map: { eventListeners: {} } });
+        ReactDOM.render(<Plugin
+            onLoadingMapPlugins={(loading) => {
+                if (!loading) {
+                    expect(document.querySelector('.mapLoadingMessage')).toBeTruthy();
+                    done();
+                }
+            }}
+            pluginsCreator={() => Promise.resolve({
+                Map: ({ children }) => <div className="map">{children}</div>,
+                Layer: ({ options }) => <div id={options.id} className="layers">{options.type}</div>,
+                Feature: () => null,
+                tools: {
+                    overview: () => null,
+                    scalebar: () => null,
+                    draw: () => null,
+                    highlight: () => null,
+                    selection: () => null,
+                    popup: () => null,
+                    box: () => null
+                },
+                mapType: 'openlayers'
+            })}
+            on
+        />, document.getElementById("container"));
+    });
 });

--- a/web/client/reducers/__tests__/widgets-test.js
+++ b/web/client/reducers/__tests__/widgets-test.js
@@ -218,6 +218,34 @@ describe('Test the widgets reducer', () => {
         expect(uWidgets[0].dependenciesMap).toBeFalsy();
         expect(uWidgets[0].id).toBe("2");
     });
+    it('test deleteWidget if the some other widgets [not deleted] has dependenciesMap = {}', () => {
+        const state = {
+            containers: {
+                [DEFAULT_TARGET]: {
+                    widgets: [{
+                        id: "1",
+                        maps: [{mapId: 1, layers: [1, 2]}]
+                    }, {
+                        id: "2",
+                        mapSync: true,
+                        dependenciesMap: {
+                            layers: "widgets[1].maps[1].layers"
+                        }
+                    }, {
+                        id: "3",
+                        mapSync: true,
+                        dependenciesMap: {}
+                    }]
+                }
+            }
+        };
+        const newState = widgets(state, deleteWidget({id: "1"}));
+        const uWidgets = newState.containers[DEFAULT_TARGET].widgets;
+        expect(uWidgets.length).toBe(2);
+        expect(uWidgets[0].mapSync).toBeFalsy();
+        expect(uWidgets[0].dependenciesMap).toBeFalsy();
+        expect(uWidgets[0].id).toBe("2");
+    });
     it('init', () => {
         const defaults = {initialSize: {
             w: 4,

--- a/web/client/reducers/catalog.js
+++ b/web/client/reducers/catalog.js
@@ -22,6 +22,7 @@ import {
     CHANGE_SERVICE_FORMAT,
     FOCUS_SERVICES_LIST,
     ADD_CATALOG_SERVICE,
+    UPDATE_CATALOG_SERVICES,
     DELETE_CATALOG_SERVICE,
     SAVING_SERVICE,
     CHANGE_METADATA_TEMPLATE,
@@ -170,6 +171,11 @@ function catalog(state = {
             }),
             layerError: null
         });
+    }
+    case UPDATE_CATALOG_SERVICES: {
+        return {...state,
+            services: action.services
+        };
     }
     case CHANGE_SELECTED_SERVICE: {
         if (action.service !== state.selectedService) {

--- a/web/client/reducers/layers.js
+++ b/web/client/reducers/layers.js
@@ -31,7 +31,8 @@ import {
     SELECT_NODE,
     FILTER_LAYERS,
     SHOW_LAYER_METADATA,
-    HIDE_LAYER_METADATA
+    HIDE_LAYER_METADATA,
+    REPLACE_LAYERS
 } from '../actions/layers';
 
 import { TOGGLE_CONTROL } from '../actions/controls';
@@ -173,6 +174,12 @@ function layers(state = { flat: [] }, action) {
             return assign({}, state, {groups: newNodes, flat: newLayers});
         }
         return state;
+    }
+    case REPLACE_LAYERS: {
+        return {
+            ...state,
+            layers: action.layers
+        };
     }
     case UPDATE_NODE: {
         const updatedNode = changeNodeConfiguration({

--- a/web/client/reducers/widgets.js
+++ b/web/client/reducers/widgets.js
@@ -182,7 +182,7 @@ function widgetsReducer(state = emptyState, action) {
         const allWidgets = get(updatedState, path, []);
         return set(path, allWidgets.map(m => {
             if (m.dependenciesMap) {
-                const [, dependentWidgetId] = WIDGETS_REGEX.exec((Object.values(m.dependenciesMap) || [])[0]);
+                const [, dependentWidgetId] = WIDGETS_REGEX.exec((Object.values(m.dependenciesMap) || [])[0]) || [];
                 if (dependentWidgetId) {
                     if (action.widget.id === dependentWidgetId) {
                         return {...omit(m, "dependenciesMap"), mapSync: false};

--- a/web/client/translations/data.da-DK.json
+++ b/web/client/translations/data.da-DK.json
@@ -1477,6 +1477,18 @@
       "servicePlaceholder": "type a service",
       "url": "URL",
       "urlPlaceholder": "type a URL",
+      "urlPlaceHolders": {
+        "wfs": "f.eks. https://mydomain.com/geoserver/wfs",
+        "wmts": "f.eks. https://mydomain.com/geoserver/gwc/service/wmts",
+        "wms": "f.eks. https://mydomain.com/geoserver/wms",
+        "csw": "f.eks. https://mydomain.com/geoserver/csw",
+        "tms": "f.eks. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+        "custom": "f.eks. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+        "3dtiles": "f.eks. https://mydomain.com/tileset.json",
+        "cog": "f.eks. https://mydomain.com/cog.tif",
+        "model": "f.eks. https://mydomain.com/filename.ifc",
+        "arcgis": "f.eks. https://mydomain.com/arcgis/rest/services"
+      },
       "type": "Type",
       "serviceTitle": "Title",
       "serviceTitlePlaceholder": "type a title",

--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -1642,6 +1642,18 @@
             "servicePlaceholder": "Geben Sie einen Service ein",
             "url": "Url",
             "urlPlaceholder": "Geben Sie eine URL ein",
+            "urlPlaceHolders": {
+                "wfs": "z.B. https://mydomain.com/geoserver/wfs",
+                "wmts": "z.B. https://mydomain.com/geoserver/gwc/service/wmts",
+                "wms": "z.B. https://mydomain.com/geoserver/wms",
+                "csw": "z.B. https://mydomain.com/geoserver/csw",
+                "tms": "z.B. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+                "custom": "z.B. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+                "3dtiles": "z.B. https://mydomain.com/tileset.json",
+                "cog": "z.B. https://mydomain.com/cog.tif",
+                "model": "z.B. https://mydomain.com/filename.ifc",
+                "arcgis": "z.B. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Typ",
             "serviceTitle": "Titel",
             "serviceTitlePlaceholder": "Geben Sie einen Titel ein",

--- a/web/client/translations/data.en-US.json
+++ b/web/client/translations/data.en-US.json
@@ -1601,6 +1601,18 @@
             "servicePlaceholder": "type a service",
             "url": "URL",
             "urlPlaceholder": "type a URL",
+            "urlPlaceHolders": {
+                "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+                "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+                "wms": "e.g. https://mydomain.com/geoserver/wms",
+                "csw": "e.g. https://mydomain.com/geoserver/csw",
+                "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+                "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+                "3dtiles": "e.g. https://mydomain.com/tileset.json",
+                "cog": "e.g. https://mydomain.com/cog.tif",
+                "model": "e.g. https://mydomain.com/filename.ifc",
+                "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Title",
             "serviceTitlePlaceholder": "type a title",

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -1604,6 +1604,18 @@
             "service": "Servicio",
             "url": "Url",
             "urlPlaceholder": "escribe la URL",
+            "urlPlaceHolders": {
+                "wfs": "p.ej. https://mydomain.com/geoserver/wfs",
+                "wmts": "p.ej. https://mydomain.com/geoserver/gwc/service/wmts",
+                "wms": "p.ej. https://mydomain.com/geoserver/wms",
+                "csw": "p.ej. https://mydomain.com/geoserver/csw",
+                "tms": "p.ej. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+                "custom": "p.ej. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+                "3dtiles": "p.ej. https://mydomain.com/tileset.json",
+                "cog": "p.ej. https://mydomain.com/cog.tif",
+                "model": "p.ej. https://mydomain.com/filename.ifc",
+                "arcgis": "p.ej. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Tipo",
             "serviceTitle": "Título",
             "serviceTitlePlaceholder": "escribe un título",

--- a/web/client/translations/data.fi-FI.json
+++ b/web/client/translations/data.fi-FI.json
@@ -1198,6 +1198,18 @@
       "servicePlaceholder": "kirjoita palvelu",
       "url": "URL",
       "urlPlaceholder": "kirjoita URL-osoite",
+      "urlPlaceHolders": {
+        "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+        "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+        "wms": "e.g. https://mydomain.com/geoserver/wms",
+        "csw": "e.g. https://mydomain.com/geoserver/csw",
+        "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+        "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+        "3dtiles": "e.g. https://mydomain.com/tileset.json",
+        "cog": "e.g. https://mydomain.com/cog.tif",
+        "model": "e.g. https://mydomain.com/filename.ifc",
+        "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+      },
       "type": "Tyyppi",
       "serviceTitle": "Otsikko",
       "serviceTitlePlaceholder": "kirjoita otsikko",

--- a/web/client/translations/data.fr-FR.json
+++ b/web/client/translations/data.fr-FR.json
@@ -1604,6 +1604,18 @@
             "servicePlaceholder": "Tapez un service",
             "url": "URL",
             "urlPlaceholder": "tapez une URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Titre",
             "serviceTitlePlaceholder": "tapez un titre",

--- a/web/client/translations/data.hr-HR.json
+++ b/web/client/translations/data.hr-HR.json
@@ -1156,6 +1156,18 @@
             "servicePlaceholder": "unesi servis",
             "url": "Url",
             "urlPlaceholder": "unesi URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Tip",
             "serviceTitle": "Naslov",
             "serviceTitlePlaceholder": "unesi naslov",

--- a/web/client/translations/data.is-IS.json
+++ b/web/client/translations/data.is-IS.json
@@ -1481,6 +1481,18 @@
       "servicePlaceholder": "type a service",
       "url": "URL",
       "urlPlaceholder": "type a URL",
+      "urlPlaceHolders": {
+        "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+        "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+        "wms": "e.g. https://mydomain.com/geoserver/wms",
+        "csw": "e.g. https://mydomain.com/geoserver/csw",
+        "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+        "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+        "3dtiles": "e.g. https://mydomain.com/tileset.json",
+        "cog": "e.g. https://mydomain.com/cog.tif",
+        "model": "e.g. https://mydomain.com/filename.ifc",
+        "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+      },
       "type": "Type",
       "serviceTitle": "Title",
       "serviceTitlePlaceholder": "type a title",

--- a/web/client/translations/data.it-IT.json
+++ b/web/client/translations/data.it-IT.json
@@ -1603,6 +1603,18 @@
             "servicePlaceholder": "seleziona un servizio",
             "url": "Url",
             "urlPlaceholder": "inserisci un url",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Tipo",
             "serviceTitle": "Titolo",
             "serviceTitlePlaceholder": "inserisci un titolo",

--- a/web/client/translations/data.nl-NL.json
+++ b/web/client/translations/data.nl-NL.json
@@ -1597,6 +1597,18 @@
             "servicePlaceholder": "typ een service",
             "url": "URL",
             "urlPlaceholder": "typ een URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "custom": "e.g. https://{s}.myUrl.com/{variant}/{z}/{x}/{y}",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Titel",
             "serviceTitlePlaceholder": "Typ een titel",

--- a/web/client/translations/data.pt-PT.json
+++ b/web/client/translations/data.pt-PT.json
@@ -1133,6 +1133,17 @@
             "servicePlaceholder": "type a service",
             "url": "Url",
             "urlPlaceholder": "type a URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Title",
             "serviceTitlePlaceholder": "type a title",

--- a/web/client/translations/data.sk-SK.json
+++ b/web/client/translations/data.sk-SK.json
@@ -1412,6 +1412,17 @@
             "servicePlaceholder": "Zadaj názov služby",
             "url": "URL",
             "urlPlaceholder": "Zadaj adresu URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Nadpis",
             "serviceTitlePlaceholder": "Zadaj nadpis",

--- a/web/client/translations/data.sv-SE.json
+++ b/web/client/translations/data.sv-SE.json
@@ -1391,6 +1391,17 @@
             "servicePlaceholder": "skriv en tjänst",
             "url": "URL",
             "urlPlaceholder": "skriv en webbadress",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Typ",
             "serviceTitle": "Titel",
             "serviceTitlePlaceholder": "skriv en titel",

--- a/web/client/translations/data.vi-VN.json
+++ b/web/client/translations/data.vi-VN.json
@@ -177,6 +177,17 @@
             "type": "Loại",
             "url": "URL",
             "urlPlaceholder": "gõ một URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "wfsGetCapLink": "WFS",
             "wmsGetCapLink": "WMS"
         },

--- a/web/client/translations/data.zh-ZH.json
+++ b/web/client/translations/data.zh-ZH.json
@@ -1110,6 +1110,17 @@
             "servicePlaceholder": "type a service",
             "url": "Url",
             "urlPlaceholder": "type a URL",
+            "urlPlaceHolders": {
+              "wfs": "e.g. https://mydomain.com/geoserver/wfs",
+              "wmts": "e.g. https://mydomain.com/geoserver/gwc/service/wmts",
+              "wms": "e.g. https://mydomain.com/geoserver/wms",
+              "csw": "e.g. https://mydomain.com/geoserver/csw",
+              "tms": "e.g. https://mydomain.com/geoserver/gwc/service/tms/1.0.0",
+              "3dtiles": "e.g. https://mydomain.com/tileset.json",
+              "cog": "e.g. https://mydomain.com/cog.tif",
+              "model": "e.g. https://mydomain.com/filename.ifc",
+              "arcgis": "e.g. https://mydomain.com/arcgis/rest/services"
+            },
             "type": "Type",
             "serviceTitle": "Title",
             "serviceTitlePlaceholder": "type a title",


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request' s commits. -->

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
Current we add CoreSpatial theme and styles directly to the submodule. 


**What is the new behavior?**
<!-- Describe here the new behaviour based on your changes -->
This PRs reverts the theme and styling changes in submodule since a new PR will be adding a custom theme to the root.
## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
