### PR TITLE
fix: address critical Dependabot security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redux-devtools-dock-monitor": "1.1.2",
     "redux-devtools-log-monitor": "1.3.0",
     "redux-mock-store": "1.2.2",
-    "simple-git": "2.20.1",
+    "simple-git": "^3.36.0",
     "style-loader": "2.0.0",
     "terser": "5.18.1",
     "url-loader": "0.5.7",
@@ -133,7 +133,7 @@
     "@turf/polygon-to-linestring": "4.1.0",
     "@znemz/cesium-navigation": "4.0.0",
     "assert": "2.0.0",
-    "axios": "0.30.2",
+    "axios": "^1.15.0",
     "@babel/standalone": "7.23.9",
     "bootstrap": "3.4.1",
     "buffer": "6.0.3",
@@ -299,5 +299,10 @@
     "json:write": "prettier --ignore-path .prettierignore --write \"./**/*.json\""
   },
   "author": "GeoSolutions",
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause",
+  "overrides": {
+    "nth-check": ">=2.0.1",
+    "postcss": ">=8.5.9",
+    "webpack-dev-server": ">=5.2.2"
+  }
 }


### PR DESCRIPTION
## Security fixes

Addresses critical and high severity Dependabot alerts in `package.json`:

| Package | CVE(s) | Severity | Change |
|---------|--------|----------|--------|
| simple-git | CVE-2022-24433, CVE-2022-24066, CVE-2022-25860, CVE-2022-25912, CVE-2023-40022 | CRITICAL (CVSS 9.8) | 2.20.1 → ^3.36.0 |
| axios | CVE-2025-27152 | HIGH | 0.30.2 → ^1.15.0 |
| webpack-dev-server | CVE-2024-29180, CVE-2025-30360 | HIGH | override → >=5.2.2 |
| nth-check | CVE-2021-3803 | HIGH | override → >=2.0.1 |
| postcss | CVE-2023-44270 | MODERATE | override → >=8.5.9 |

## Notes

- `simple-git` RCE (CVSS 9.8) is the most urgent — argument injection allows arbitrary OS command execution on build/CI hosts
- `axios` is the only **production runtime** vulnerability (SSRF bypass) — all others are dev/build tooling
- `webpack-dev-server` 5.x has breaking API changes — `devServer` config in `webpack.config.js` will need updating before dev mode works again (follow-on task)
- Upstream `geosolutions-it/MapStore2` ships the same unpatched versions — these fixes must be maintained independently in this fork