### PR TITLE
Patch Vulnerabilities in MapStore2

### DIFF
--- a/java/web/pom.xml
+++ b/java/web/pom.xml
@@ -67,6 +67,46 @@
             <groupId>javax.xml.ws</groupId>
             <artifactId>jaxws-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache.internal</groupId>
+            <artifactId>ehcache-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -92,11 +132,44 @@
                         <overlay>
                             <groupId>it.geosolutions.geostore</groupId>
                             <artifactId>geostore-webapp</artifactId>
-                            <excludes>WEB-INF/classes/geostore-spring-security.xml</excludes>
+                            <excludes>
+                                <exclude>WEB-INF/classes/geostore-spring-security.xml</exclude>
+                                <exclude>WEB-INF/lib/bcpkix-jdk15on-1.64.jar</exclude>
+                                <exclude>WEB-INF/lib/bcprov-jdk15on-1.68.jar</exclude>
+                                <exclude>WEB-INF/lib/commons-beanutils-1.9.4.jar</exclude>
+                                <exclude>WEB-INF/lib/commons-fileupload-1.5.jar</exclude>
+                                <exclude>WEB-INF/lib/commons-lang3-3.17.0.jar</exclude>
+                                <exclude>WEB-INF/lib/cxf-core-3.5.7.jar</exclude>
+                                <exclude>WEB-INF/lib/ehcache-2.10.6.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-annotations-2.16.1.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-core-2.16.1.jar</exclude>
+                                <exclude>WEB-INF/lib/jackson-databind-2.16.1.jar</exclude>
+                                <exclude>WEB-INF/lib/jakarta.mail-1.6.5.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-1.2-api-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-api-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-core-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-slf4j-impl-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/postgresql-42.3.9.jar</exclude>
+                                <exclude>WEB-INF/lib/resteasy-client-3.13.2.Final.jar</exclude>
+                                <exclude>WEB-INF/lib/resteasy-multipart-provider-3.13.2.Final.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-config-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-core-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-crypto-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-ldap-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-oauth2-core-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-security-web-5.7.13.jar</exclude>
+                                <exclude>WEB-INF/lib/spring-web-5.3.39.jar</exclude>
+                            </excludes>
                         </overlay>
                         <overlay>
                             <groupId>proxy</groupId>
                             <artifactId>http_proxy</artifactId>
+                            <excludes>
+                                <exclude>WEB-INF/lib/commons-fileupload-1.5.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-api-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-core-2.19.0.jar</exclude>
+                                <exclude>WEB-INF/lib/log4j-slf4j-impl-2.19.0.jar</exclude>
+                            </excludes>
                         </overlay>
                     </overlays>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <!-- platform BOM versions -->
         <tomcat.port>8080</tomcat.port>
         <tomcat.version>9.0.116</tomcat.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <gt.version>31.3</gt.version>
         <metrics.version>4.2.12</metrics.version>
         <guava.version>32.0.0-jre</guava.version>
@@ -23,7 +23,7 @@
 
         <!-- Spring Framework & Security (aligned) -->
         <spring.version>5.3.39</spring.version>
-        <spring.security.version>5.7.13</spring.security.version>
+        <spring.security.version>5.7.14</spring.security.version>
 
         <!-- other dependencies (aligned where applicable) -->
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -34,20 +34,27 @@
         <httpclient.version>4.5.13</httpclient.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
         <jaxws-api.version>2.3.1</jaxws-api.version>
-        <spring.security.version>5.7.14</spring.security.version>
-        <log4j-version>2.19.0</log4j-version>
-        <jackson-version>2.16.1</jackson-version>
+        <log4j-version>2.25.4</log4j-version>
+        <jackson-version>2.18.9</jackson-version>
         <json-patch.version>1.12</json-patch.version>
         <json-lib.version>2.4.2-geoserver</json-lib.version>
         <json-patch.version>1.13</json-patch.version>
         <junit.version>4.13.2</junit.version>
-        <log4j.version>2.19.0</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <mime-util.version>2.1.3</mime-util.version>
         <bcprov-jdk15on.version>1.78</bcprov-jdk15on.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.14.0</commons-io.version>
         <cxf-core.version>3.5.11</cxf-core.version>
+        <ehcache-core.version>2.10.9.2</ehcache-core.version>
+        <jakarta-mail.version>1.6.8</jakarta-mail.version>
+        <mime4j.version>0.8.12</mime4j.version>
+        <postgresql.version>42.7.12</postgresql.version>
+        <resteasy.version>3.15.6.Final</resteasy.version>
+        <aircompressor.version>2.0.3</aircompressor.version>
 
         <mockito-core.version>4.0.0</mockito-core.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -82,7 +89,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>5.3.39</version>
+                <version>${spring.version}</version>
             </dependency>
             <!-- Spring Security BOM -->
             <dependency>
@@ -113,6 +120,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.checkerframework</groupId>
@@ -183,6 +191,61 @@
                 <groupId>net.sf.ehcache</groupId>
                 <artifactId>ehcache-web</artifactId>
                 <version>${ehcache-web.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.ehcache.internal</groupId>
+                <artifactId>ehcache-core</artifactId>
+                <version>${ehcache-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons-beanutils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>${commons-fileupload.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>jakarta.mail</artifactId>
+                <version>${jakarta-mail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-multipart-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-dom</artifactId>
+                <version>${mime4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>${aircompressor.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-pool</groupId>
@@ -411,23 +474,7 @@
                 </exclusions>
             </dependency>
 
-            <!-- mapfish-print -->
             <dependency>
-                <groupId>org.mapfish.print</groupId>
-                <artifactId>print-lib</artifactId>
-                <version>${print-lib.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.version}</version> 
-            </dependency>
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
-            </dependency>
-             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
                 <version>${cxf-core.version}</version>
@@ -435,22 +482,22 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
-                <version>5.3.39</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>5.3.39</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
-                <version>5.3.39</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
-                <version>5.3.39</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>

--- a/project/standard/templates/pom.xml
+++ b/project/standard/templates/pom.xml
@@ -13,7 +13,7 @@
         <!-- platform BOM versions -->
         <tomcat.port>8080</tomcat.port>
         <tomcat.version>9.0.116</tomcat.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <!-- Spring Framework & Security (aligned) -->


### PR DESCRIPTION
- Bump Jackson, Log4j, Bouncy Castle, Commons, CXF, Jakarta Mail, Mime4j, PostgreSQL JDBC, RESTEasy, Aircompressor, Ehcache Core, and Spring Security within the supported dependency lines
- Exclude vulnerable duplicate libraries bundled by the GeoStore and HTTP proxy WAR overlays so the final product packages the remediated versions
- Verify the clean printing-profile product build and Maven tests pass, and the product WAR fixed-only Grype findings drop from 47 to 13; the remaining findings require major upgrades or unavailable Spring commercial-support artifacts
