### PR TITLE
CGSP-197: account for chatbot panel in map layout offset

### DIFF
--- a/web/client/epics/maplayout.js
+++ b/web/client/epics/maplayout.js
@@ -121,6 +121,7 @@ export const updateMapLayoutEpic = (action$, store) =>
                 get(state, "controls.userExtensions.enabled") && { right: mapLayout.right.md } || null,
                 get(state, "controls.mapTemplates.enabled") && { right: mapLayout.right.md } || null,
                 get(state, "controls.mapCatalog.enabled") && { right: mapLayout.right.md } || null,
+                get(state, "controls.chatbot.enabled") && { right: mapLayout.right.md } || null,
                 mapInfoEnabledSelector(state) && isMapInfoOpen(state) && !isMouseMoveIdentifyActiveSelector(state) && {right: mapLayout.right.md} || null
             ].filter(panel => panel)) || {right: 0};
 


### PR DESCRIPTION
## Summary

The new Chatbot sidebar panel being added in [ngs-mapstore PR #113](https://github.com/ngsllc/ngs-mapstore/pull/113) docks on the right of the map, same as `Details`, `MetadataExplorer`, and `MapTemplates`. Those panels are registered in `updateMapLayoutEpic`'s `rightPanels` list so other right-anchored controls (search bar, zoom controls) shift left to make room when they open. `chatbot` wasn't in that list, so those controls stayed put and visually overlapped the panel.

This adds `controls.chatbot.enabled` to the existing whitelist, matching the pattern already used for `mapTemplates` and `mapCatalog`.

Based on `patch-vulns-2026.2.2` (rather than `latest_release`) because that's the commit ngs-mapstore's local environment actually builds against right now — `latest_release`'s tip predates the dependency cleanup that removed `react-addons-css-transition-group`, which is no longer installed.

## Test plan

- [x] Opened a blank map locally with the Chatbot plugin enabled, confirmed the search bar and zoom controls shift left when the panel opens and return to their original position when it closes
- [x] No other right-docked panel's behavior changed (diff is additive, one list entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)